### PR TITLE
Make license field SPDX-compatible

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ test:
 
 about:
   home: https://github.com/elastic/elasticsearch-py
-  license: Apache 2.0
+  license: Apache-2.0
   license_file: LICENSE
   license_family: Apache
   summary: Python client for Elasticsearch


### PR DESCRIPTION
Linter issue caused by no dash